### PR TITLE
Исправление HQL запросов на получение топиков

### DIFF
--- a/src/main/java/ru/javamentor/dao/TopicDAOImpl.java
+++ b/src/main/java/ru/javamentor/dao/TopicDAOImpl.java
@@ -52,16 +52,16 @@ public class TopicDAOImpl implements TopicDAO {
 
     @Override
     public List<Topic> getAllTopicsByUserId(Long userId) {
-        return entityManager.createQuery("SELECT t FROM Topic t JOIN FETCH t.authors a JOIN FETCH t.hashtags h JOIN FETCH a.role r  WHERE a.id = :userId", Topic.class).setParameter("userId", userId).getResultList();
+        return entityManager.createQuery("SELECT t FROM Topic t LEFT JOIN FETCH t.authors a LEFT JOIN FETCH t.hashtags h LEFT JOIN FETCH a.role r  WHERE a.id = :userId GROUP BY t.id", Topic.class).setParameter("userId", userId).getResultList();
     }
 
     @Override
     public List<Topic> getTotalListOfTopics() {
-        return entityManager.createQuery("SELECT t FROM Topic t JOIN FETCH t.authors a JOIN FETCH t.hashtags h JOIN FETCH a.role r", Topic.class).getResultList();
+        return entityManager.createQuery("SELECT t FROM Topic t LEFT JOIN FETCH t.hashtags h LEFT JOIN FETCH t.authors a LEFT JOIN FETCH a.role r GROUP BY t.id", Topic.class).getResultList();
     }
 
     public List<User> getAllUsersByTopicId(Long topicId) {
-        return entityManager.createQuery("SELECT u FROM Topic t JOIN t.authors u WHERE t.id = :topicId", User.class).setParameter("topicId", topicId).getResultList();
+        return entityManager.createQuery("SELECT u FROM Topic t LEFT JOIN FETCH t.authors u WHERE t.id = :topicId GROUP BY u.id", User.class).setParameter("topicId", topicId).getResultList();
     }
 
     /**
@@ -72,7 +72,7 @@ public class TopicDAOImpl implements TopicDAO {
     @Override
     public List<Topic> getAllTopicsByHashtag(String value) {
         return entityManager
-                .createQuery("SELECT t FROM Topic t JOIN FETCH t.authors a JOIN FETCH t.hashtags h JOIN FETCH a.role r WHERE h.name = :value", Topic.class)
+                .createQuery("SELECT t FROM Topic t LEFT JOIN FETCH t.authors a LEFT JOIN FETCH t.hashtags h LEFT JOIN FETCH a.role r WHERE h.name = :value GROUP BY t.id", Topic.class)
                         .setParameter("value", value)
                         .getResultList();
     }
@@ -86,7 +86,7 @@ public class TopicDAOImpl implements TopicDAO {
     @Override
     public List<Topic> getAllTopicsOfUserByHashtag(Long userId, String value) {
         return entityManager
-                .createQuery("SELECT t FROM Topic t JOIN FETCH t.authors a JOIN FETCH t.hashtags h JOIN FETCH a.role r WHERE h.name = :value AND a.id = :userId", Topic.class)
+                .createQuery("SELECT t FROM Topic t LEFT JOIN FETCH t.authors a LEFT JOIN FETCH t.hashtags h LEFT JOIN FETCH a.role r WHERE h.name = :value AND a.id = :userId GROUP BY t.id", Topic.class)
                         .setParameter("value", value)
                         .setParameter("userId", userId)
                         .getResultList();
@@ -113,7 +113,7 @@ public class TopicDAOImpl implements TopicDAO {
     @Override
     public List<Topic> getNotModeratedTopicsPage(int page, int pageSize) {
         return entityManager
-                .createQuery("SELECT t FROM Topic t JOIN FETCH t.authors a JOIN FETCH t.hashtags h JOIN FETCH a.role r WHERE t.isModerate = false", Topic.class)
+                .createQuery("SELECT t FROM Topic t LEFT JOIN FETCH t.authors a LEFT JOIN FETCH t.hashtags h LEFT JOIN FETCH a.role r WHERE t.isModerate = false GROUP BY t.id", Topic.class)
                 .setFirstResult(pageSize * (page-1))
                 .setMaxResults(pageSize)
                 .getResultList();

--- a/src/main/resources/static/js/admin-moderate-events.js
+++ b/src/main/resources/static/js/admin-moderate-events.js
@@ -15,7 +15,7 @@ $(document).ready(function(){
                                 '<button id="p_1" class="page-link page-btn" type="button">1</button>' +
                             '</li>');
 
-        for (let i = 2; i <= Math.floor(count/pageSize); i++) {
+        for (let i = 2; i <= Math.ceil(count/pageSize); i++) {
             page_buttons.append('<li id="pi_' + i + '" class="page-item">' +
                                     '<button id="p_' + i + '" class="page-link page-btn" type="button">' + i + '</button>' +
                                 '</li>');


### PR DESCRIPTION
- во всех запросах на получение топиков изменил JOIN на LEFT JOIN. Это критически важно для связи таблиц topics и hashtags. Т.к. не у всех записей могут быть хэштеги. И, соответсвенно, при любом запросе на получение топиков, топики без хэштегов будут игнорироваться.
- добавил в запросы GROUP BY, т.к. во многих запросах происходило задваивание результатов. Например, если у одного топика указать 3 автора, то в итоге этот топик будет выведен 3 раза.
- поправил округление количества страниц в скрипте построения админской страницы.